### PR TITLE
refactor: 엔티티에서 공통 필드를 추출하여 BaseEntity로 분리

### DIFF
--- a/src/main/kotlin/com/study/kotlog/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/study/kotlog/domain/BaseEntity.kt
@@ -1,0 +1,25 @@
+package com.study.kotlog.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
+import java.time.ZonedDateTime
+
+@MappedSuperclass
+abstract class BaseEntity {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private val _id: Long? = null
+    val id: Long
+        get() = _id!!
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: ZonedDateTime = ZonedDateTime.now()
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: ZonedDateTime = ZonedDateTime.now()
+}

--- a/src/main/kotlin/com/study/kotlog/domain/comment/Comment.kt
+++ b/src/main/kotlin/com/study/kotlog/domain/comment/Comment.kt
@@ -1,0 +1,20 @@
+package com.study.kotlog.domain.comment
+
+import com.study.kotlog.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "comments")
+class Comment(
+
+    @Column(name = "post_id", nullable = false)
+    val postId: Long,
+
+    @Column(name = "author_id", nullable = false)
+    val authorId: Long,
+
+    @Column(name = "content", nullable = false)
+    val content: String
+) : BaseEntity()

--- a/src/main/kotlin/com/study/kotlog/domain/like/Like.kt
+++ b/src/main/kotlin/com/study/kotlog/domain/like/Like.kt
@@ -1,0 +1,17 @@
+package com.study.kotlog.domain.like
+
+import com.study.kotlog.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "likes")
+class Like(
+
+    @Column(name = "post_id", nullable = false)
+    val postId: Long,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: Long
+) : BaseEntity()

--- a/src/main/kotlin/com/study/kotlog/domain/post/Post.kt
+++ b/src/main/kotlin/com/study/kotlog/domain/post/Post.kt
@@ -1,0 +1,20 @@
+package com.study.kotlog.domain.post
+
+import com.study.kotlog.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "posts")
+class Post(
+
+    @Column(name = "post_id", nullable = false)
+    val postId: Long,
+
+    @Column(name = "author_id", nullable = false)
+    val authorId: Long,
+
+    @Column(name = "content", nullable = false)
+    val content: String
+) : BaseEntity()

--- a/src/main/kotlin/com/study/kotlog/domain/tag/Tag.kt
+++ b/src/main/kotlin/com/study/kotlog/domain/tag/Tag.kt
@@ -1,0 +1,14 @@
+package com.study.kotlog.domain.tag
+
+import com.study.kotlog.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "tags")
+class Tag(
+
+    @Column(name = "name", nullable = false)
+    val name: String
+) : BaseEntity()

--- a/src/main/kotlin/com/study/kotlog/domain/user/User.kt
+++ b/src/main/kotlin/com/study/kotlog/domain/user/User.kt
@@ -1,0 +1,23 @@
+package com.study.kotlog.domain.user
+
+import com.study.kotlog.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "users")
+class User(
+
+    @Column(name = "user_name", nullable = false)
+    val username: String,
+
+    @Column(name = "password", nullable = false)
+    var password: String,
+
+    @Column(name = "email", nullable = false)
+    var email: String,
+
+    @Column(name = "nickname", nullable = false)
+    var nickname: String,
+) : BaseEntity()


### PR DESCRIPTION
중복되는 `id`, `createdAt`, `updatedAt` 필드를 `BaseEntity`로 분리하여
모든 엔티티가 `BaseEntity`를 상속하도록 수정하였습니다.