### PR TITLE
feat: Kotlin 2.1 대응을 위한 Ktlint 13.0.0-rc.1 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,14 @@
+import org.jlleitschuh.gradle.ktlint.KtlintExtension
+
 plugins {
-    kotlin("jvm") version "1.9.25"
-    kotlin("plugin.spring") version "1.9.25"
     id("org.springframework.boot") version "3.5.0"
     id("io.spring.dependency-management") version "1.1.7"
-    id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
-    kotlin("plugin.jpa") version "1.9.25"
+    id("org.jlleitschuh.gradle.ktlint") version "13.0.0-rc.1"
+
+    val kotlinVersion = "2.1.20"
+    kotlin("jvm") version kotlinVersion
+    kotlin("plugin.spring") version kotlinVersion
+    kotlin("plugin.jpa") version kotlinVersion
 }
 
 group = "com.study"
@@ -39,6 +43,33 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
+configure<KtlintExtension> {
+    // ktlint에 넘길 에디터컨피그(editorconfig) 옵션들을 맵 형태로 지정
+    additionalEditorconfig.set(
+        mapOf(
+            // 코드 스타일을 IntelliJ IDEA 기본 스타일로 맞춘다
+            "ktlint_code_style" to "intellij_idea",
+
+            // 한 줄의 최대 길이를 250자로 허용
+            "max_line_length" to "250",
+
+            // import-on-demand (와일드카드 import, e.g. kotlin.*)를 허용할 패키지 패턴
+            "ij_kotlin_packages_to_use_import_on_demand" to "**",
+
+            // 함수 호출부(call site) 끝에 오는 trailing comma(끝쉼표)를 금지
+            "ij_kotlin_allow_trailing_comma_on_call_site" to "false",
+
+            // 컬렉션 리터럴, 함수 선언 등 일반적인 곳에서의 trailing comma는 허용
+            "ij_kotlin_allow_trailing_comma" to "true",
+
+            // 클래스 시그니처에 파라미터가 1개 이상이면 자동으로 줄바꿈(멀티라인) 강제
+            "ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than" to "1",
+
+            // 함수 시그니처에 파라미터가 2개 이상이면 자동으로 줄바꿈(멀티라인) 강제
+            "ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than" to "2"
+        )
+    )
+}
 kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict")


### PR DESCRIPTION
기존에 사용하던 ktlint 12.3.0이 Kotlin 2.1과 호환되지 않아 13.0.0-rc.1로 업그레이드하였습니다.

ktlint 12.x는 내부적으로 ktlint 엔진 0.49.1을 사용하며 
해당 버전은 Kotlin 2.1에서 제거된 KtTokens.HEADER_KEYWORD 필드에 접근하고 있어 빌드 오류가 발생합니다.

Kotlin 2.1을 지원하는 ktlint 엔진 1.5.0은 ktlint 플러그인 13.x부터 기본 포함되므로 플러그인 버전을 올려 호환성을 확보했습니다.