### PR TITLE
feat: 게시글 생성 로직 구현

### DIFF
--- a/src/main/kotlin/com/study/kotlog/domain/post/Post.kt
+++ b/src/main/kotlin/com/study/kotlog/domain/post/Post.kt
@@ -8,10 +8,18 @@ import jakarta.persistence.Table
 @Entity
 @Table(name = "posts")
 class Post(
-    @Column(name = "post_id", nullable = false)
-    val postId: Long,
     @Column(name = "author_id", nullable = false)
     val authorId: Long,
+    @Column(name = "title", nullable = false)
+    val title: String,
     @Column(name = "content", nullable = false)
     val content: String,
-) : BaseEntity()
+) : BaseEntity() {
+    companion object {
+        fun of(
+            authorId: Long,
+            title: String,
+            content: String,
+        ): Post = Post(authorId, title, content)
+    }
+}

--- a/src/main/kotlin/com/study/kotlog/domain/post/PostRepository.kt
+++ b/src/main/kotlin/com/study/kotlog/domain/post/PostRepository.kt
@@ -1,0 +1,5 @@
+package com.study.kotlog.domain.post
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PostRepository : JpaRepository<Post, Long>

--- a/src/main/kotlin/com/study/kotlog/domain/post/PostService.kt
+++ b/src/main/kotlin/com/study/kotlog/domain/post/PostService.kt
@@ -1,0 +1,22 @@
+package com.study.kotlog.domain.post
+
+import com.study.kotlog.domain.post.dto.CreatePostCommand
+import org.springframework.stereotype.Service
+
+@Service
+class PostService(
+    private val postRepository: PostRepository,
+) {
+
+    fun createPost(createPostCommand: CreatePostCommand): Post {
+        val post = Post.of(
+            authorId = createPostCommand.authorId,
+            title = createPostCommand.title,
+            content = createPostCommand.content
+        )
+
+        postRepository.save(post)
+
+        return post
+    }
+}

--- a/src/main/kotlin/com/study/kotlog/domain/post/dto/CreatePostCommand.kt
+++ b/src/main/kotlin/com/study/kotlog/domain/post/dto/CreatePostCommand.kt
@@ -1,0 +1,7 @@
+package com.study.kotlog.domain.post.dto
+
+data class CreatePostCommand(
+    val authorId: Long,
+    val title: String,
+    val content: String,
+)

--- a/src/main/kotlin/com/study/kotlog/front/controller/auth/AuthController.kt
+++ b/src/main/kotlin/com/study/kotlog/front/controller/auth/AuthController.kt
@@ -19,6 +19,7 @@ class AuthController(
 ) {
 
     @PostMapping("/signup")
+    @Operation(summary = "회원 가입", description = "사용자로부터 회원 정보를 입력받아 계정을 생성합니다. 중복된 사용자명은 가입할 수 없습니다.")
     fun signUp(@RequestBody request: SignupRequest): ResponseEntity<Void> {
         authService.signUp(request.toCommand())
         return ResponseEntity.status(HttpStatus.CREATED).build()

--- a/src/main/kotlin/com/study/kotlog/front/controller/auth/AuthController.kt
+++ b/src/main/kotlin/com/study/kotlog/front/controller/auth/AuthController.kt
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController
 class AuthController(
     private val authService: AuthService,
 ) {
-
     @PostMapping("/signup")
     @Operation(summary = "회원 가입", description = "사용자로부터 회원 정보를 입력받아 계정을 생성합니다. 중복된 사용자명은 가입할 수 없습니다.")
     fun signUp(@RequestBody request: SignupRequest): ResponseEntity<Void> {

--- a/src/main/kotlin/com/study/kotlog/front/controller/post/PostController.kt
+++ b/src/main/kotlin/com/study/kotlog/front/controller/post/PostController.kt
@@ -16,8 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 class PostController(
     private val postService: PostService,
 ) {
-
-    @PostMapping("/create")
+    @PostMapping
     @Operation(summary = "post 생성", description = "현재 userId 로 게시물을 생성합니다.")
     fun createPost(
         userId: Long,

--- a/src/main/kotlin/com/study/kotlog/front/controller/post/PostController.kt
+++ b/src/main/kotlin/com/study/kotlog/front/controller/post/PostController.kt
@@ -1,0 +1,30 @@
+package com.study.kotlog.front.controller.post
+
+import com.study.kotlog.domain.post.PostService
+import com.study.kotlog.front.controller.post.dto.CreatePostRequest
+import com.study.kotlog.front.controller.post.dto.PostResponse
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/posts")
+class PostController(
+    private val postService: PostService,
+) {
+
+    @PostMapping("/create")
+    @Operation(summary = "post 생성", description = "현재 userId 로 게시물을 생성합니다.")
+    fun createPost(
+        userId: Long,
+        @RequestBody request: CreatePostRequest,
+    ): ResponseEntity<PostResponse> {
+        val post = postService.createPost(request.toCommand(userId))
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(PostResponse.from(post))
+    }
+}

--- a/src/main/kotlin/com/study/kotlog/front/controller/post/dto/CreatePostRequest.kt
+++ b/src/main/kotlin/com/study/kotlog/front/controller/post/dto/CreatePostRequest.kt
@@ -1,0 +1,18 @@
+package com.study.kotlog.front.controller.post.dto
+
+import com.study.kotlog.domain.post.dto.CreatePostCommand
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "게시글 생성 DTO")
+data class CreatePostRequest(
+    @Schema(description = "게시글 제목", example = "kotlog 만들기")
+    val title: String,
+    @Schema(description = "게시글 내용", example = "kotlin 으로 블로그를 만들어보겠습니다.")
+    val content: String,
+) {
+    fun toCommand(authorId: Long): CreatePostCommand = CreatePostCommand(
+        authorId = authorId,
+        title = this.title,
+        content = this.content
+    )
+}

--- a/src/main/kotlin/com/study/kotlog/front/controller/post/dto/PostResponse.kt
+++ b/src/main/kotlin/com/study/kotlog/front/controller/post/dto/PostResponse.kt
@@ -1,0 +1,17 @@
+package com.study.kotlog.front.controller.post.dto
+
+import com.study.kotlog.domain.post.Post
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Post 생성 후 반환 DTO")
+data class PostResponse(
+
+    @Schema(description = "게시물 id", example = "1L")
+    val postId: Long,
+) {
+    companion object {
+        fun from(post: Post): PostResponse = PostResponse(
+            postId = post.id
+        )
+    }
+}

--- a/src/main/kotlin/com/study/kotlog/front/controller/user/UserController.kt
+++ b/src/main/kotlin/com/study/kotlog/front/controller/user/UserController.kt
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController
 class UserController(
     val userRepository: UserRepository,
 ) {
-
     @GetMapping("/me")
     @Operation(summary = "내 정보 조회", description = "userId 를 기반으로 사용자 정보를 조회합니다.")
     fun me(userId: Long): ResponseEntity<UserResponse> {

--- a/src/test/kotlin/com/study/kotlog/domain/post/PostServiceTest.kt
+++ b/src/test/kotlin/com/study/kotlog/domain/post/PostServiceTest.kt
@@ -1,0 +1,28 @@
+package com.study.kotlog.domain.post
+
+import com.study.kotlog.domain.post.dto.CreatePostCommand
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class PostServiceTest(
+    val postService: PostService,
+    val postRepository: PostRepository,
+) : FunSpec({
+    test("게시물 하나 등록 성공") {
+        val command = CreatePostCommand(
+            authorId = 1L,
+            title = "게시물 하나를 테스트 하는 법",
+            content = "너무 덥고 아이스 아메리카노가 먹고싶습니다."
+        )
+
+        val response = postService.createPost(command)
+
+        val savedPost = postRepository.findById(response.id).get()
+
+        savedPost.title shouldBe command.title
+        savedPost.content shouldBe command.content
+        savedPost.authorId shouldBe command.authorId
+    }
+})


### PR DESCRIPTION
사용자 ID(`userId`)를 기반으로 게시글을 생성하는 기능을 구현했습니다.

- 게시글 제목 및 내용에 대한 정책(글자 수 제한, 금지어 필터링 등)은 나중에 구현 예정